### PR TITLE
Normalize header keys before fetch

### DIFF
--- a/addon/mixins/version-header-handler.js
+++ b/addon/mixins/version-header-handler.js
@@ -18,6 +18,10 @@ const {
   Mixin,
 } = Ember;
 
+function fetchHeader(header, headers) {
+  return headers[header] || headers[header.toLowerCase()];
+}
+
 export default Mixin.create({
   newVersionDetector: service(),
 
@@ -32,7 +36,7 @@ export default Mixin.create({
 
   handleResponse(_, headers) {
     runNext(this, function() {
-      this.set('newVersionDetector.activeVersion', headers['X-Current-Version']);
+      this.set('newVersionDetector.activeVersion', fetchHeader('X-Current-Version', headers));
     });
 
     return this._super(...arguments);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-new-version-detection",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Our snazzy add-on for checking if a new version of your app is available",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
NOTE: these are normalized in newer versions of ember, but not old