### PR TITLE
Ignore certain upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ export default class MyAdapter extends VersionDetectingJsonApiAdapter {
 }
 ```
 
+### I want to ignore an upgrade
+
+Not a problem. Example:
+
+```javascript
+this.newVersionDetector.ignoreThisUpgrade();
+```
+
 ### Help! I Don't Use JSON:API!
 
 The implementation of the adapter is pretty straightforward. Just copy and paste from our code.

--- a/addon/adapter/json-api.js
+++ b/addon/adapter/json-api.js
@@ -27,7 +27,7 @@ export default class VersionDetectingJsonApiAdapter extends JSONAPIAdapter {
 
   handleResponse(_, headers) {
     runNext(this, function () {
-      this.newVersionDetector.set('activeVersion', fetchHeader('X-Current-Version', headers));
+      this.newVersionDetector.activeVersion = fetchHeader('X-Current-Version', headers);
     });
 
     return super.handleResponse(...arguments);

--- a/addon/services/new-version-detector.js
+++ b/addon/services/new-version-detector.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 
-import { tracked } from 'tracked-built-ins';
+import { tracked } from '@glimmer/tracking';
 
 import config from 'ember-get-config';
 
@@ -13,8 +13,9 @@ export default class NewVersionDetector extends Service {
   @tracked
   activeVersion = null;
 
-  // ignoredVersions (optional): string[] -- versions the user doesn't care about, perhaps they just want to get on with their life
-  ignoredVersions = tracked([]);
+  // ignoredVersions (optional): string -- version the user doesn't care about, perhaps they just want to get on with their life
+  @tracked
+  ignoredVersion = null;
 
   // Version as reported by the app build
   @tracked
@@ -38,13 +39,13 @@ export default class NewVersionDetector extends Service {
   }
 
   get isUpgradeAvailable() {
-    const { activeVersion, currentVersion, ignoredVersions } = this;
+    const { activeVersion, currentVersion, ignoredVersion } = this;
 
     return (
       currentVersion &&
       activeVersion &&
       currentVersion !== activeVersion &&
-      !ignoredVersions.includes(activeVersion)
+      ignoredVersion !== activeVersion
     );
   }
 
@@ -52,8 +53,6 @@ export default class NewVersionDetector extends Service {
    * Ignores the current upgrade. Subsequent upgrades will not be ignored.
    */
   ignoreThisUpgrade() {
-    const { activeVersion } = this;
-
-    this.ignoredVersions.push(activeVersion);
+    this.ignoredVersion = this.activeVersion;
   }
 }

--- a/addon/services/new-version-detector.js
+++ b/addon/services/new-version-detector.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 
-import { computed } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 import config from 'ember-get-config';
 
@@ -10,16 +10,16 @@ const {
 
 export default class NewVersionDetector extends Service {
   // activeVersion (optional): string -- the version currently active, as reported by the API
+  @tracked
   activeVersion = null;
 
+  @tracked
   _rawVersion = version;
 
-  @computed('_rawVersion')
   get reportedVersion() {
     return this._rawVersion?.slice(6);
   }
 
-  @computed('_rawVersion')
   get currentVersion() {
     const rawVersion = this._rawVersion;
 
@@ -33,7 +33,6 @@ export default class NewVersionDetector extends Service {
     }
   }
 
-  @computed('currentVersion', 'activeVersion')
   get isUpgradeAvailable() {
     const { currentVersion, activeVersion } = this;
 

--- a/addon/services/new-version-detector.js
+++ b/addon/services/new-version-detector.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 
-import { tracked } from '@glimmer/tracking';
+import { tracked } from 'tracked-built-ins';
 
 import config from 'ember-get-config';
 
@@ -13,6 +13,10 @@ export default class NewVersionDetector extends Service {
   @tracked
   activeVersion = null;
 
+  // ignoredVersions (optional): string[] -- versions the user doesn't care about, perhaps they just want to get on with their life
+  ignoredVersions = tracked([]);
+
+  // Version as reported by the app build
   @tracked
   _rawVersion = version;
 
@@ -34,8 +38,22 @@ export default class NewVersionDetector extends Service {
   }
 
   get isUpgradeAvailable() {
-    const { currentVersion, activeVersion } = this;
+    const { activeVersion, currentVersion, ignoredVersions } = this;
 
-    return currentVersion && activeVersion && currentVersion !== activeVersion;
+    return (
+      currentVersion &&
+      activeVersion &&
+      currentVersion !== activeVersion &&
+      !ignoredVersions.includes(activeVersion)
+    );
+  }
+
+  /**
+   * Ignores the current upgrade. Subsequent upgrades will not be ignored.
+   */
+  ignoreThisUpgrade() {
+    const { activeVersion } = this;
+
+    this.ignoredVersions.push(activeVersion);
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-get-config": "^0.3.0",
-    "git-repo-info": "^2.1.0"
+    "git-repo-info": "^2.1.0",
+    "tracked-built-ins": "^1.0.2"
   },
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
@@ -67,7 +68,8 @@
     "npm-run-all": "^4.1.5",
     "pretender": "^3.0.5",
     "prettier": "^2.2.1",
-    "qunit-dom": "^1.5.0"
+    "qunit-dom": "^1.5.0",
+    "qunit-wait-for": "^2.0.0"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-get-config": "^0.3.0",
-    "git-repo-info": "^2.1.0",
-    "tracked-built-ins": "^1.0.2"
+    "git-repo-info": "^2.1.0"
   },
   "devDependencies": {
     "@ember/jquery": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "bugs": "https://github.com/PrecisionNutrition/ember-new-version-detection/issues",
   "homepage": "https://github.com/PrecisionNutrition/ember-new-version-detection",
   "dependencies": {
+    "@glimmer/tracking": "^1.0.2",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-get-config": "^0.3.0",
@@ -34,7 +35,6 @@
     "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^2.0.0",
     "@glimmer/component": "^1.0.2",
-    "@glimmer/tracking": "^1.0.2",
     "@precision-nutrition/prettier-config": "^1.1.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/tests/acceptance/detecting-a-new-version-test.js
+++ b/tests/acceptance/detecting-a-new-version-test.js
@@ -68,4 +68,58 @@ module('Acceptance | detecting a new version', function (hooks) {
 
     assert.dom('#alert').exists('detects a new version is available');
   });
+
+  test('ignoring a version', async function (assert) {
+    const { headers, responseBody } = this;
+
+    const service = this.owner.lookup('service:new-version-detector');
+
+    this.server = new Pretender(function () {
+      this.get('/foos', function (req) {
+        const { requestHeaders } = req;
+
+        assert.equal(
+          requestHeaders['X-App-Name'],
+          env['ember-new-version-detection'].appName,
+          'reports the app name to the server'
+        );
+
+        assert.ok('X-App-Version' in requestHeaders, 'reports the app version to the server');
+
+        return [200, headers, responseBody];
+      });
+
+      this.get('/foos/1', function () {
+        headers['X-Current-Version'] = '26716999';
+
+        return [200, headers, responseBody];
+      });
+    });
+
+    await visit('/foo');
+
+    assert.dom('#alert').doesNotExist('does not signal new version when not available');
+
+    await visit('/foo-new-version');
+
+    assert.dom('#alert').exists('detects a new version is available');
+
+    service.ignoreThisUpgrade();
+
+    await assert.waitFor(() => {
+      assert.dom('#alert').doesNotExist('current reported version is ignored');
+    });
+
+    this.server.get('/foos', function () {
+      headers['X-Current-Version'] = '123123123';
+
+      return [200, headers, responseBody];
+    });
+
+    await visit('/foo');
+
+    await assert.waitFor(() => {
+      assert.dom('#alert').exists('detects a new version is available');
+    });
+  });
 });

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,6 +3,11 @@ import config from 'dummy/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 
+import QUnit from 'qunit';
+import { installWaitFor } from 'qunit-wait-for';
+
+installWaitFor(QUnit);
+
 setApplication(Application.create(config.APP));
 
 start();

--- a/tests/unit/services/new-version-detector-test.js
+++ b/tests/unit/services/new-version-detector-test.js
@@ -60,7 +60,7 @@ module('Unit | Service | new version detector', function (hooks) {
 
       assert.notOk(this.service.isUpgradeAvailable);
 
-      assert.deepEqual(this.service.ignoredVersions, ['2'], 'retains a list of ignored versions');
+      assert.equal(this.service.ignoredVersion, '2', 'marks active version as ignored');
 
       this.service.activeVersion = '3';
 
@@ -70,11 +70,7 @@ module('Unit | Service | new version detector', function (hooks) {
 
       assert.notOk(this.service.isUpgradeAvailable);
 
-      assert.deepEqual(
-        this.service.ignoredVersions,
-        ['2', '3'],
-        'appends to the list of ignored versions'
-      );
+      assert.equal(this.service.ignoredVersion, '3', 'marks new active version as ignored');
     });
   });
 });

--- a/tests/unit/services/new-version-detector-test.js
+++ b/tests/unit/services/new-version-detector-test.js
@@ -9,7 +9,7 @@ module('Unit | Service | new version detector', function (hooks) {
   });
 
   test('#reportedVersion', function (assert) {
-    this.service.set('_rawVersion', '0.0.0+079a4760');
+    this.service._rawVersion = '0.0.0+079a4760';
 
     let reportedVersion = this.service.reportedVersion;
 
@@ -17,7 +17,7 @@ module('Unit | Service | new version detector', function (hooks) {
   });
 
   test('#currentVersion', function (assert) {
-    this.service.set('_rawVersion', '0.0.0+079a4760');
+    this.service._rawVersion = '0.0.0+079a4760';
 
     let currentVersion = this.service.currentVersion;
 
@@ -25,24 +25,22 @@ module('Unit | Service | new version detector', function (hooks) {
   });
 
   test('it indicates when current version is newest available', function (assert) {
-    this.service.setProperties({
-      _rawVersion: '0.0.0+079a4760',
-      activeVersion: '079a476',
-    });
+    this.service._rawVersion = '0.0.0+079a4760';
+    this.service.activeVersion = '079a476';
 
     assert.notOk(this.service.isUpgradeAvailable);
 
-    this.service.set('_rawVersion', '0.0.0+2');
+    this.service._rawVersion = '0.0.0+2';
 
     assert.ok(this.service.isUpgradeAvailable);
 
-    this.service.setProperties('_rawVersion', '0.0.0+3');
+    this.service._rawVersion = '0.0.0+3';
 
     assert.ok(this.service.isUpgradeAvailable);
   });
 
   test('it is false when activeVersion is null', function (assert) {
-    this.service.set('_rawVersion', '3');
+    this.service._rawVersion = '3';
 
     assert.notOk(this.service.isUpgradeAvailable);
   });

--- a/tests/unit/services/new-version-detector-test.js
+++ b/tests/unit/services/new-version-detector-test.js
@@ -44,4 +44,37 @@ module('Unit | Service | new version detector', function (hooks) {
 
     assert.notOk(this.service.isUpgradeAvailable);
   });
+
+  module('#ignoreThisUpgrade', function (hooks) {
+    hooks.beforeEach(function () {
+      this.service._rawVersion = '0.0.0+079a4760';
+      this.service.activeVersion = '079a476';
+    });
+
+    test('when upgrade is available', function (assert) {
+      this.service.activeVersion = '2';
+
+      assert.ok(this.service.isUpgradeAvailable);
+
+      this.service.ignoreThisUpgrade();
+
+      assert.notOk(this.service.isUpgradeAvailable);
+
+      assert.deepEqual(this.service.ignoredVersions, ['2'], 'retains a list of ignored versions');
+
+      this.service.activeVersion = '3';
+
+      assert.ok(this.service.isUpgradeAvailable);
+
+      this.service.ignoreThisUpgrade();
+
+      assert.notOk(this.service.isUpgradeAvailable);
+
+      assert.deepEqual(
+        this.service.ignoredVersions,
+        ['2', '3'],
+        'appends to the list of ignored versions'
+      );
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,7 +2670,7 @@
     "@handlebars/parser" "^1.1.0"
     simple-html-tokenizer "^0.5.10"
 
-"@glimmer/tracking@^1.0.2":
+"@glimmer/tracking@^1.0.0", "@glimmer/tracking@^1.0.2":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.0.3.tgz#8b9b42aff6c206edeaaea178a95acc1eff62e61e"
   integrity sha512-21WR13vPdzt1IQ6JmPPAu4szjV9yKdmLHV3nD0MLDj6/EoYv1c2PqpFBBlp++6xW8OnyDa++cQ8OFoQDP+MRpA==
@@ -6455,7 +6455,7 @@ ember-cli-babel@^6.8.1:
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0:
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.23.0.tgz#ec580aa2c115d0810e454dd5c2fffce238284b92"
   integrity sha512-ix58DlRDAbGITtdJoRUPcAoQwKLYr/x/kIXjU9u1ATyhmuUjqb+0FDXghOWbkNihGiNOqBBR49+LBgK9AeBcNw==
@@ -11632,6 +11632,11 @@ qunit-dom@^1.5.0:
     ember-cli-babel "^7.23.0"
     ember-cli-version-checker "^5.1.1"
 
+qunit-wait-for@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/qunit-wait-for/-/qunit-wait-for-2.0.0.tgz#f90f4a1c554bf8405222b5a361063747b23f023f"
+  integrity sha512-ASDc/Xlx0QxrBRX2j1/PBLJVw0HW/I6DYL6ipmLy3r5X8uP0pYLNxPq7cU7iGg0ZOCriB7OUi4If2M9XGUxmsw==
+
 qunit@^2.9.3:
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.9.3.tgz#9522a088e76f0782f70a45db92f2fd14db311bcc"
@@ -13439,6 +13444,23 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
+
+tracked-built-ins@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tracked-built-ins/-/tracked-built-ins-1.0.2.tgz#3e1e802e85dacba232b1a8d9ffe67b67250c4c9b"
+  integrity sha512-sgxUMq9as38Jj2kMgJDHvfiMALU3EWHdQ7bWsKgY9G19UuOKJsQrvWbkAjGLO6DzyZjlgxqDWAX9F60HdAo/ow==
+  dependencies:
+    ember-cli-babel "^7.18.0"
+    ember-cli-typescript "^3.0.0"
+    tracked-maps-and-sets "^2.0.0"
+
+tracked-maps-and-sets@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tracked-maps-and-sets/-/tracked-maps-and-sets-2.2.0.tgz#94b1e79733d358021983519255ca70d8c8cd3585"
+  integrity sha512-zg70p8VYCWXFrHtnfnGE7QCVGBVqfsZAdfwf9PeZR4j7NmBJmIJFMbYi+xodnnL6y6wzpv4IHKgOwHs+PiEm6g==
+  dependencies:
+    "@glimmer/tracking" "^1.0.0"
+    ember-cli-babel "^7.17.2"
 
 tree-sync@^1.2.2:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,7 +2670,7 @@
     "@handlebars/parser" "^1.1.0"
     simple-html-tokenizer "^0.5.10"
 
-"@glimmer/tracking@^1.0.0", "@glimmer/tracking@^1.0.2":
+"@glimmer/tracking@^1.0.2":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.0.3.tgz#8b9b42aff6c206edeaaea178a95acc1eff62e61e"
   integrity sha512-21WR13vPdzt1IQ6JmPPAu4szjV9yKdmLHV3nD0MLDj6/EoYv1c2PqpFBBlp++6xW8OnyDa++cQ8OFoQDP+MRpA==
@@ -6455,7 +6455,7 @@ ember-cli-babel@^6.8.1:
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0:
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.23.0.tgz#ec580aa2c115d0810e454dd5c2fffce238284b92"
   integrity sha512-ix58DlRDAbGITtdJoRUPcAoQwKLYr/x/kIXjU9u1ATyhmuUjqb+0FDXghOWbkNihGiNOqBBR49+LBgK9AeBcNw==
@@ -13444,23 +13444,6 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
-
-tracked-built-ins@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/tracked-built-ins/-/tracked-built-ins-1.0.2.tgz#3e1e802e85dacba232b1a8d9ffe67b67250c4c9b"
-  integrity sha512-sgxUMq9as38Jj2kMgJDHvfiMALU3EWHdQ7bWsKgY9G19UuOKJsQrvWbkAjGLO6DzyZjlgxqDWAX9F60HdAo/ow==
-  dependencies:
-    ember-cli-babel "^7.18.0"
-    ember-cli-typescript "^3.0.0"
-    tracked-maps-and-sets "^2.0.0"
-
-tracked-maps-and-sets@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tracked-maps-and-sets/-/tracked-maps-and-sets-2.2.0.tgz#94b1e79733d358021983519255ca70d8c8cd3585"
-  integrity sha512-zg70p8VYCWXFrHtnfnGE7QCVGBVqfsZAdfwf9PeZR4j7NmBJmIJFMbYi+xodnnL6y6wzpv4IHKgOwHs+PiEm6g==
-  dependencies:
-    "@glimmer/tracking" "^1.0.0"
-    ember-cli-babel "^7.17.2"
 
 tree-sync@^1.2.2:
   version "1.4.0"


### PR DESCRIPTION
# What Changed & Why

It's desirable to ignore upgrades sometimes. This change allows us to mark a new active version as ignored. This is done in memory, so refreshing the page will restore the banner.